### PR TITLE
Fix typo in template literal example

### DIFF
--- a/ebook/04_template_literals.md
+++ b/ebook/04_template_literals.md
@@ -95,7 +95,7 @@ The syntax for a ternary operator looks like this:
 ```js
 const isDiscounted = false
 
-return isFridgeEmpty ? "$10" : "$20"
+return isDiscounted ? "$10" : "$20"
 // $20
 ```
 


### PR DESCRIPTION
the example makes only sense when the same variable name is used in both lines